### PR TITLE
BTUC-18788: Fix crash on invalid texture access

### DIFF
--- a/src/quick/scenegraph/adaptations/software/qsgsoftwareinternalimagenode_p.h
+++ b/src/quick/scenegraph/adaptations/software/qsgsoftwareinternalimagenode_p.h
@@ -132,7 +132,7 @@ private:
     QRectF m_innerSourceRect;
     QRectF m_subSourceRect;
 
-    QSGTexture *m_texture;
+    QPointer<QSGTexture> m_texture;
     QPixmap m_cachedMirroredPixmap;
 
     bool m_mirror;


### PR DESCRIPTION
In some rare case the accessed texture has been destroyed causing a
crash. Use QPointer to prevent accessing of invalid textures.

Change-Id: Ibefba54c9f44b042a9d58d71503328d3b03a67ee