### PR TITLE
BTUC-18861: Endless loop fixed for qquicktext.

### DIFF
--- a/src/quick/items/qquicktext.cpp
+++ b/src/quick/items/qquicktext.cpp
@@ -2277,6 +2277,9 @@ void QQuickText::geometryChanged(const QRectF &newGeometry, const QRectF &oldGeo
         d->updateLayout();
     } else {
         // We just need to re-layout
+        if (d->_anchors) {
+            QQuickAnchorsPrivate::get(d->_anchors)->updateMe();
+        }
         d->updateSize();
     }
 


### PR DESCRIPTION
- Take anchors into account before size update.
- Otherwise it causes endless loop in
QQuickWindowPrivate::polishItems(): item got
updated twice and returns back to original
geometry.

Change-Id: I3906f93b9bf698bb9bf966fe5450dfd821fd1db6