### PR TITLE
BTUC-21035: Add null check

### DIFF
--- a/src/quick/items/qquickwindow.cpp
+++ b/src/quick/items/qquickwindow.cpp
@@ -345,7 +345,7 @@ static void updatePixelRatioHelper(QQuickItem *item, float pixelRatio)
 void QQuickWindow::physicalDpiChanged()
 {
     Q_D(QQuickWindow);
-    const qreal newPixelRatio = screen()->devicePixelRatio();
+    const qreal newPixelRatio = screen() ? screen()->devicePixelRatio() : 1.0; //never return 0
     if (qFuzzyCompare(newPixelRatio, d->devicePixelRatio))
         return;
     d->devicePixelRatio = newPixelRatio;


### PR DESCRIPTION
 - Add null check Virtual Driver maybe causes
   Qt to lose screen.

Change-Id: I6b16775bb420f2cc6803a7ad2ec0494d790c58ef